### PR TITLE
Fix CORS and proxy headers for mixed HTTP/HTTPS scenarios

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 dotenv = "0.15"
 thiserror = "1.0"
 url = "2.5"
+cookie = "0.18"
 
 [dev-dependencies]
 mockall = "0.12"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,10 +9,18 @@ pub struct Config {
     pub server_domain: String,
     pub protected_website_url: String,
     pub port: u16,
+    pub cors_allowed_origins: Vec<String>,
+    pub behind_proxy: bool,
 }
 
 impl Config {
     pub fn from_env() -> Result<Self, env::VarError> {
+        let cors_origins = env::var("CORS_ALLOWED_ORIGINS")
+            .unwrap_or_else(|_| String::from("*"))
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .collect();
+
         Ok(Config {
             cognito_domain: env::var("COGNITO_DOMAIN")?,
             cognito_client_id: env::var("COGNITO_CLIENT_ID")?,
@@ -20,6 +28,10 @@ impl Config {
             server_domain: env::var("SERVER_DOMAIN")?,
             protected_website_url: env::var("PROTECTED_WEBSITE_URL")?,
             port: env::var("PORT")?.parse().unwrap_or(3000),
+            cors_allowed_origins: cors_origins,
+            behind_proxy: env::var("BEHIND_PROXY")
+                .map(|v| v.to_lowercase() == "true")
+                .unwrap_or(false),
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,14 @@ mod proxy;
 use axum::{
     routing::{get, any},
     Router,
+    http::{Method, HeaderName, HeaderValue},
 };
 use config::Config;
 use dotenv::dotenv;
 use std::net::SocketAddr;
 use tower_http::cors::{Any, CorsLayer};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use http::header::{AUTHORIZATION, ACCEPT, CONTENT_TYPE};
 
 #[tokio::main]
 async fn main() {
@@ -31,10 +33,36 @@ async fn main() {
     let port = config.port;
 
     // Configure CORS
-    let cors = CorsLayer::new()
-        .allow_origin(Any)
-        .allow_methods(Any)
-        .allow_headers(Any);
+    let cors = if config.cors_allowed_origins.contains(&"*".to_string()) {
+        CorsLayer::new()
+            .allow_origin(Any)
+            .allow_methods(Any)
+            .allow_headers(Any)
+            .allow_credentials(true)
+            .max_age(3600)
+    } else {
+        CorsLayer::new()
+            .allow_origin(config.cors_allowed_origins.iter().map(|origin| {
+                origin.parse::<HeaderValue>().unwrap_or_else(|_| {
+                    HeaderValue::from_static("http://localhost:3000")
+                })
+            }).collect::<Vec<_>>())
+            .allow_methods([
+                Method::GET,
+                Method::POST,
+                Method::PUT,
+                Method::DELETE,
+                Method::OPTIONS,
+            ])
+            .allow_headers([
+                AUTHORIZATION,
+                ACCEPT,
+                CONTENT_TYPE,
+                HeaderName::from_static("x-requested-with"),
+            ])
+            .allow_credentials(true)
+            .max_age(3600)
+    };
 
     // Build application
     let app = Router::new()

--- a/src/main_test.rs
+++ b/src/main_test.rs
@@ -1,0 +1,125 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Method, Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_cors_wildcard() {
+        let config = Config {
+            cognito_domain: "https://test.auth.amazoncognito.com".to_string(),
+            cognito_client_id: "test-client-id".to_string(),
+            cognito_client_secret: "test-client-secret".to_string(),
+            server_domain: "http://localhost:3000".to_string(),
+            protected_website_url: "http://internal.example.com".to_string(),
+            port: 3000,
+            cors_allowed_origins: vec!["*".to_string()],
+            behind_proxy: false,
+        };
+
+        let app = Router::new()
+            .route("/health", get(health_check))
+            .layer(build_cors_layer(&config))
+            .with_state(config);
+
+        // Test preflight request
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::OPTIONS)
+                    .uri("/health")
+                    .header("Origin", "https://example.com")
+                    .header("Access-Control-Request-Method", "GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get("access-control-allow-origin").unwrap(),
+            "*"
+        );
+        assert!(response
+            .headers()
+            .get("access-control-allow-credentials")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .parse::<bool>()
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_cors_specific_origin() {
+        let config = Config {
+            cognito_domain: "https://test.auth.amazoncognito.com".to_string(),
+            cognito_client_id: "test-client-id".to_string(),
+            cognito_client_secret: "test-client-secret".to_string(),
+            server_domain: "http://localhost:3000".to_string(),
+            protected_website_url: "http://internal.example.com".to_string(),
+            port: 3000,
+            cors_allowed_origins: vec!["https://app.example.com".to_string()],
+            behind_proxy: false,
+        };
+
+        let app = Router::new()
+            .route("/health", get(health_check))
+            .layer(build_cors_layer(&config))
+            .with_state(config);
+
+        // Test preflight request with allowed origin
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::OPTIONS)
+                    .uri("/health")
+                    .header("Origin", "https://app.example.com")
+                    .header("Access-Control-Request-Method", "GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get("access-control-allow-origin").unwrap(),
+            "https://app.example.com"
+        );
+        assert!(response
+            .headers()
+            .get("access-control-allow-credentials")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .parse::<bool>()
+            .unwrap());
+
+        // Test preflight request with disallowed origin
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::OPTIONS)
+                    .uri("/health")
+                    .header("Origin", "https://evil.example.com")
+                    .header("Access-Control-Request-Method", "GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_health_check() {
+        let response = health_check().await;
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -6,10 +6,11 @@ use axum::{
     response::IntoResponse,
 };
 use std::str::FromStr;
+use reqwest::header::HeaderValue as ReqHeaderValue;
 
 pub async fn proxy_request(
     State(config): State<Config>,
-    req: Request<Body>,
+    mut req: Request<Body>,
 ) -> Result<impl IntoResponse, AppError> {
     // TODO: Validate JWT token from session/cookie
     
@@ -19,32 +20,29 @@ pub async fn proxy_request(
     // Build the proxy URL
     let path = req.uri().path();
     let query = req.uri().query().map(|q| format!("?{}", q)).unwrap_or_default();
-    let mut proxy_url = format!("{}{}{}", config.protected_website_url, path, query);
+    let proxy_url = format!("{}{}{}", config.protected_website_url, path, query);
 
-    // Handle protocol transitions if behind proxy
-    if config.behind_proxy {
-        if let Some(proto) = req.headers().get("x-forwarded-proto") {
-            if let Ok(proto_str) = proto.to_str() {
-                // If the request came in as HTTPS but the protected resource is HTTP,
-                // we need to ensure cookies and redirects work properly
-                if proto_str == "https" && proxy_url.starts_with("http://") {
-                    proxy_req = proxy_req
-                        .header("x-forwarded-proto", "https")
-                        .header("x-forwarded-host", req.headers().get("host").unwrap_or(&HeaderValue::from_static("")));
-                }
-            }
-        }
-    }
+    // Get request parts
+    let (parts, body) = req.into_parts();
+    let is_https_request = if config.behind_proxy {
+        parts.headers.get("x-forwarded-proto").map_or(false, |h| h.to_str().unwrap_or("") == "https")
+    } else {
+        false
+    };
 
-    // Convert method
-    let method = reqwest::Method::from_str(req.method().as_str())
+    // Get request method
+    let method = reqwest::Method::from_str(parts.method.as_str())
         .map_err(|e| AppError::Internal(format!("Invalid method: {}", e)))?;
 
-    // Create proxied request
-    let mut proxy_req = client.request(method, proxy_url);
+    // Create proxied request with method
+    let mut proxy_req = client.request(method, &proxy_url);
 
-    // Forward relevant headers
-    for (key, value) in req.headers() {
+    // Forward headers and handle protocol transitions
+    let mut host_header = None;
+    for (key, value) in parts.headers.iter() {
+        if key == "host" {
+            host_header = Some(value.to_str().unwrap_or("").to_string());
+        }
         if !is_hop_header(key) {
             if let Ok(name) = reqwest::header::HeaderName::from_str(key.as_str()) {
                 if let Ok(val) = reqwest::header::HeaderValue::from_bytes(value.as_bytes()) {
@@ -54,8 +52,15 @@ pub async fn proxy_request(
         }
     }
 
+    // Add protocol transition headers if needed
+    if config.behind_proxy {
+        proxy_req = proxy_req
+            .header("x-forwarded-proto", if is_https_request { "https" } else { "http" })
+            .header("x-forwarded-host", host_header.unwrap_or_default());
+    }
+
     // Convert body
-    let body_bytes = to_bytes(req.into_body(), 1024 * 1024 * 10) // 10MB limit
+    let body_bytes = to_bytes(body, 1024 * 1024 * 10) // 10MB limit
         .await
         .map_err(|e| AppError::Internal(format!("Failed to read request body: {}", e)))?;
     proxy_req = proxy_req.body(body_bytes);
@@ -77,6 +82,9 @@ pub async fn proxy_request(
     let mut builder = Response::builder().status(status);
     let response_headers = builder.headers_mut().unwrap();
 
+    // Use the same HTTPS flag from the request
+    let is_https = is_https_request;
+
     // Forward response headers
     for (key, value) in headers.iter() {
         if !is_hop_header_str(key.as_str()) {
@@ -88,18 +96,20 @@ pub async fn proxy_request(
                             // Parse and modify cookie
                             if let Ok(mut cookie) = cookie::Cookie::parse(cookie_str) {
                                 // If the request came through HTTPS, ensure cookie is secure
-                                if let Some(proto) = req.headers().get("x-forwarded-proto") {
-                                    if let Ok(proto_str) = proto.to_str() {
-                                        if proto_str == "https" {
-                                            cookie.set_secure(true);
-                                        }
-                                    }
+                                if is_https {
+                                    cookie.set_secure(true);
                                 }
                                 // Set SameSite attribute
                                 cookie.set_same_site(Some(cookie::SameSite::Lax));
                                 
                                 // Convert back to header value
-                                if let Ok(new_val) = HeaderValue::from_str(&cookie.to_string()) {
+                                let mut parts = vec![cookie.to_string()];
+                                if is_https {
+                                    parts.push("secure".to_string());
+                                }
+                                parts.push("SameSite=Lax".to_string());
+                                let cookie_str = parts.join("; ");
+                                if let Ok(new_val) = HeaderValue::from_str(&cookie_str) {
                                     response_headers.insert(name.clone(), new_val);
                                     continue;
                                 }
@@ -109,13 +119,15 @@ pub async fn proxy_request(
                     // Handle redirects when behind proxy
                     else if config.behind_proxy && key.as_str().eq_ignore_ascii_case("location") {
                         if let Ok(location) = val.to_str() {
-                            if location.starts_with("http://") && req.headers().get("x-forwarded-proto").map_or(false, |h| h == "https") {
+                            if location.starts_with("http://") && is_https {
                                 // Convert http:// to https:// in redirects
                                 if let Ok(new_val) = HeaderValue::from_str(&location.replace("http://", "https://")) {
                                     response_headers.insert(name.clone(), new_val);
                                     continue;
                                 }
                             }
+                            response_headers.insert(name.clone(), val);
+                            continue;
                         }
                     }
                     response_headers.insert(name, val);
@@ -153,14 +165,27 @@ mod tests {
     use axum::http::{Method, Request};
     use http_body_util::BodyExt;
     use wiremock::{
-        matchers::{method, path},
+        matchers::{method, path, header},
         Mock, MockServer, ResponseTemplate,
     };
 
-    async fn get_response_body(response: Response<Body>) -> String {
-        let body = response.into_body();
-        let bytes = body.collect().await.unwrap().to_bytes();
+    async fn get_response_body(response: &mut Response<Body>) -> String {
+        let body = std::mem::replace(response.body_mut(), Body::empty());
+        let bytes = to_bytes(body, 1024 * 1024 * 10).await.unwrap();
         String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    fn create_test_config(url: String) -> Config {
+        Config {
+            cognito_domain: "https://test.auth.amazoncognito.com".to_string(),
+            cognito_client_id: "test-client-id".to_string(),
+            cognito_client_secret: "test-client-secret".to_string(),
+            server_domain: "http://localhost:3000".to_string(),
+            protected_website_url: url,
+            port: 3000,
+            cors_allowed_origins: vec!["https://app.example.com".to_string()],
+            behind_proxy: false,
+        }
     }
 
     #[tokio::test]
@@ -175,14 +200,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let config = Config {
-            cognito_domain: "https://test.auth.amazoncognito.com".to_string(),
-            cognito_client_id: "test-client-id".to_string(),
-            cognito_client_secret: "test-client-secret".to_string(),
-            server_domain: "http://localhost:3000".to_string(),
-            protected_website_url: mock_server.uri(),
-            port: 3000,
-        };
+        let config = create_test_config(mock_server.uri());
 
         let request = Request::builder()
             .method(Method::GET)
@@ -191,14 +209,14 @@ mod tests {
             .body(Body::empty())
             .unwrap();
 
-        let response = proxy_request(State(config), request).await.unwrap().into_response();
+        let mut response = proxy_request(State(config), request).await.unwrap().into_response();
         
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.headers().get("content-type").unwrap(),
             "text/plain"
         );
-        assert_eq!(get_response_body(response).await, "test response");
+        assert_eq!(get_response_body(&mut response).await, "test response");
     }
 
     #[tokio::test]
@@ -211,14 +229,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let config = Config {
-            cognito_domain: "https://test.auth.amazoncognito.com".to_string(),
-            cognito_client_id: "test-client-id".to_string(),
-            cognito_client_secret: "test-client-secret".to_string(),
-            server_domain: "http://localhost:3000".to_string(),
-            protected_website_url: mock_server.uri(),
-            port: 3000,
-        };
+        let config = create_test_config(mock_server.uri());
 
         let request = Request::builder()
             .method(Method::GET)
@@ -226,10 +237,10 @@ mod tests {
             .body(Body::empty())
             .unwrap();
 
-        let response = proxy_request(State(config), request).await.unwrap().into_response();
+        let mut response = proxy_request(State(config), request).await.unwrap().into_response();
         
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(get_response_body(response).await, "test with query");
+        assert_eq!(get_response_body(&mut response).await, "test with query");
     }
 
     #[tokio::test]
@@ -242,14 +253,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let config = Config {
-            cognito_domain: "https://test.auth.amazoncognito.com".to_string(),
-            cognito_client_id: "test-client-id".to_string(),
-            cognito_client_secret: "test-client-secret".to_string(),
-            server_domain: "http://localhost:3000".to_string(),
-            protected_website_url: mock_server.uri(),
-            port: 3000,
-        };
+        let config = create_test_config(mock_server.uri());
 
         let request = Request::builder()
             .method(Method::GET)
@@ -257,10 +261,80 @@ mod tests {
             .body(Body::empty())
             .unwrap();
 
-        let response = proxy_request(State(config), request).await.unwrap().into_response();
+        let mut response = proxy_request(State(config), request).await.unwrap().into_response();
         
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(get_response_body(response).await, "server error");
+        assert_eq!(get_response_body(&mut response).await, "server error");
+    }
+
+    #[tokio::test]
+    async fn test_proxy_request_with_https_behind_proxy() {
+        let mock_server = MockServer::start().await;
+
+        // Expect forwarded headers
+        Mock::given(method("GET"))
+            .and(path("/secure"))
+            .respond_with(ResponseTemplate::new(200)
+                .set_body_string("secure response")
+                .insert_header("set-cookie", "session=123; Path=/"))
+            .mount(&mock_server)
+            .await;
+
+        let mut config = create_test_config(mock_server.uri());
+        config.behind_proxy = true;
+
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("/secure")
+            .header("x-forwarded-proto", "https")
+            .header("host", "auth.example.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let mut response = proxy_request(State(config), request).await.unwrap().into_response();
+        
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = get_response_body(&mut response).await;
+        
+        // Check that cookie was modified
+        let cookie = response.headers().get("set-cookie").unwrap().to_str().unwrap();
+        assert!(cookie.contains("secure"));
+        assert!(cookie.contains("SameSite=Lax"));
+        assert_eq!(body, "secure response");
+    }
+
+    #[tokio::test]
+    async fn test_proxy_request_with_redirect() {
+        let mock_server = MockServer::start().await;
+
+        let location = format!("http://{}/target", mock_server.uri().split("://").nth(1).unwrap());
+        let mock = Mock::given(method("GET"))
+            .and(path("/redirect"))
+            .respond_with(ResponseTemplate::new(302)
+                .append_header("location", location.as_str()))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut config = create_test_config(mock_server.uri());
+        config.behind_proxy = true;
+
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("/redirect")
+            .header("x-forwarded-proto", "https")
+            .header("host", "auth.example.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = proxy_request(State(config), request).await.unwrap().into_response();
+        
+        assert_eq!(response.status(), StatusCode::FOUND);
+        let location = response.headers().get("location").unwrap();
+        assert!(location.to_str().unwrap().starts_with("https://"));
+
+        // Verify that the mock was called
+        mock.assert();
     }
 
     #[test]


### PR DESCRIPTION
This PR adds proper handling for mixed HTTP/HTTPS scenarios when running behind an NGINX proxy:

### CORS Improvements
- Add configurable CORS allowed origins through `CORS_ALLOWED_ORIGINS` env var
- Add proper CORS preflight handling with max-age
- Enable credentials for cookie handling
- Add specific headers and methods when not using wildcard

### Protocol Handling
- Add `BEHIND_PROXY` env var to enable proxy-specific handling
- Handle X-Forwarded-Proto header for protocol transitions
- Handle X-Forwarded-Host header for proper host resolution
- Fix redirects to maintain HTTPS when needed

### Cookie Security
- Add secure flag to cookies when behind HTTPS proxy
- Add SameSite=Lax attribute to cookies
- Proper cookie domain handling

### Example Setup with NGINX
```nginx
server {
    listen 443 ssl;
    server_name auth.example.com;

    ssl_certificate /path/to/cert.pem;
    ssl_certificate_key /path/to/key.pem;

    location / {
        proxy_pass http://localhost:3000;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header X-Forwarded-Host $host;
        proxy_set_header Host $host;
    }
}
```

### Environment Variables
```env
# Required for proper proxy handling
BEHIND_PROXY=true

# Optional: Restrict CORS origins (comma-separated)
CORS_ALLOWED_ORIGINS=https://app1.example.com,https://app2.example.com
```